### PR TITLE
Add basic search tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "bun test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/data/dutyStations.test.ts
+++ b/src/data/dutyStations.test.ts
@@ -1,0 +1,42 @@
+import { searchDutyStations, dutyStations } from './dutyStations';
+import { expect, test, describe } from 'bun:test';
+
+// Helper to check that every station in result contains query in city, state, or sector
+function matchesQuery(result: ReturnType<typeof searchDutyStations>, query: string) {
+  const q = query.toLowerCase();
+  return result.every(
+    (station) =>
+      station.city.toLowerCase().includes(q) ||
+      station.state.toLowerCase().includes(q) ||
+      station.sector.toLowerCase().includes(q) ||
+      station.name.toLowerCase().includes(q)
+  );
+}
+
+describe('searchDutyStations', () => {
+  test('returns all stations when query is empty', () => {
+    const results = searchDutyStations('');
+    expect(results).toBe(dutyStations);
+  });
+
+  test('searches by city', () => {
+    const query = 'Presidio';
+    const results = searchDutyStations(query);
+    expect(results.length).toBeGreaterThan(0);
+    expect(matchesQuery(results, query)).toBe(true);
+  });
+
+  test('searches by state', () => {
+    const query = 'WA';
+    const results = searchDutyStations(query);
+    expect(results.length).toBeGreaterThan(0);
+    expect(matchesQuery(results, query)).toBe(true);
+  });
+
+  test('searches by sector', () => {
+    const query = 'Big Bend Sector Texas';
+    const results = searchDutyStations(query);
+    expect(results.length).toBeGreaterThan(0);
+    expect(matchesQuery(results, query)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add bun-based unit tests for searchDutyStations
- add `bun test` script to run tests

## Testing
- `bun test`
